### PR TITLE
Updated README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Installation
 
 2. Activate the virtual environment::
 
+   $ bash
    $ . <name>/bin/activate
 
 3. Clone the repo::


### PR DESCRIPTION
Activation of the virtual environment is now preceded by a call to `bash` to ensure a compatible shell is running before running `activate`.